### PR TITLE
Add crafting ingredients as a page for the completor

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,9 +1,11 @@
 <script>
   import Card from './Card.svelte';
   import Substance from './Substance.svelte';
+  import Ingredient from './Ingredient.svelte';
 
   import alchemicalItems from './AlchemicalItems.json';
   import alchemicalSubstances from './AlchemicalSubstances.json';
+  import craftingIngredients from './CraftingIngredients.json';
 
   let search="";
 
@@ -27,6 +29,7 @@
 let pages = [
   ["alchemicalItems","Alchemical Items"],
   ["alchemicalSubstances","Alchemical Substances"],
+  ["craftingIngredients","Crafting Ingredients"],
 ];
 let activePage = "alchemicalItems";
 </script>
@@ -101,6 +104,25 @@ let activePage = "alchemicalItems";
           </tr>
         {#each filterItems( search, alchemicalSubstances ) as substance}
           <Substance substance={substance}/>
+        {/each}
+        </table>
+      </div>
+    </div>
+  {:else if activePage == "craftingIngredients"}
+    <div class="row">
+      <div class="col">
+        <table class="table table-sm">
+          <tr>
+            <th>Name</th>
+            <th>Rarity</th>
+            <th>Location</th>
+            <th>Quantity</th>
+            <th>Forage DC</th>
+            <th>Weight</th>
+            <th>Cost</th>
+          </tr>
+        {#each filterItems( search, craftingIngredients ) as ingredient}
+          <Ingredient ingredient={ingredient}/>
         {/each}
         </table>
       </div>

--- a/src/CraftingIngredients.json
+++ b/src/CraftingIngredients.json
@@ -2,7 +2,7 @@
    {
       "name": "Ashes",
       "rarity": "E",
-      "location" : [ "Fires" , "burned items" ],
+      "location" : [ "Fires" , "Burned items" ],
       "quantity": "1d10 Units",
       "forage": "10",
       "weight": ".1",
@@ -11,7 +11,7 @@
    {
       "name": "Coal",
       "rarity": "C",
-      "location" : [ "Fires" , "mountains" , "underground" ],
+      "location" : [ "Fires" , "Mountains" , "Underground" ],
       "quantity": "1d10 Units",
       "forage": "14",
       "weight": ".1",
@@ -20,7 +20,7 @@
    {
       "name": "Cotton",
       "rarity": "C",
-      "location" : [ "Fields" , "plantations" ],
+      "location" : [ "Fields" , "Plantations" ],
       "quantity": "1d10 Units",
       "forage": "12",
       "weight": ".1",
@@ -29,7 +29,7 @@
    {
       "name": "Double Woven Linen",
       "rarity": "P",
-      "location" : [ "Bought" , "crafted" ],
+      "location" : [ "Bought" , "Crafted" ],
       "quantity": "N/A",
       "forage": "N/A",
       "weight": ".1",
@@ -38,7 +38,7 @@
    {
       "name": "Glass",
       "rarity": "P",
-      "location" : [ "Bought" , "crafted" ],
+      "location" : [ "Bought" , "Crafted" ],
       "quantity": "N/A",
       "forage": "N/A",
       "weight": ".5",
@@ -47,7 +47,7 @@
    {
       "name": "Hardened Timber",
       "rarity": "P",
-      "location" : [ "Bought" , "crafted" ],
+      "location" : [ "Bought" , "Crafted" ],
       "quantity": "N/A",
       "forage": "N/A",
       "weight": ".1",
@@ -56,7 +56,7 @@
    {
       "name": "Linen",
       "rarity": "C",
-      "location" : [ "Bought" , "crafted" ],
+      "location" : [ "Bought" , "Crafted" ],
       "quantity": "N/A",
       "forage": "N/A",
       "weight": ".1",
@@ -65,7 +65,7 @@
    {
       "name": "Oil",
       "rarity": "C",
-      "location" : [ "Bought" , "crafted" ],
+      "location" : [ "Bought" , "Crafted" ],
       "quantity": "N/A",
       "forage": "N/A",
       "weight": ".1",
@@ -92,7 +92,7 @@
    {
       "name": "Thread",
       "rarity": "C",
-      "location" : [ "Bought" , "crafted" ],
+      "location" : [ "Bought" , "Crafted" ],
       "quantity": "N/A",
       "forage": "N/A",
       "weight": ".1",
@@ -110,7 +110,7 @@
    {
       "name": "Wax",
       "rarity": "C",
-      "location" : [ "Forests" , "fields" ],
+      "location" : [ "Forests" , "Fields" ],
       "quantity": "1d6 Units",
       "forage": "12",
       "weight": ".1",
@@ -119,7 +119,7 @@
    {
       "name": "Beast Bones",
       "rarity": "C",
-      "location" : [ "Found on monsters" , "beasts" ],
+      "location" : [ "Found on monsters & beasts" ],
       "quantity": "Variable",
       "forage": "N/A",
       "weight": "4",
@@ -137,7 +137,7 @@
    {
       "name": "Draconid Leather",
       "rarity": "R",
-      "location" : [ "Bought" , "crafted" ],
+      "location" : [ "Bought" , "Crafted" ],
       "quantity": "N/A",
       "forage": "N/A",
       "weight": "5",
@@ -164,7 +164,7 @@
    {
       "name": "Hardened Leather",
       "rarity": "P",
-      "location" : [ "Bought" , "crafted" ],
+      "location" : [ "Bought" , "Crafted" ],
       "quantity": "N/A",
       "forage": "N/A",
       "weight": "3",
@@ -173,7 +173,7 @@
    {
       "name": "Leather",
       "rarity": "C",
-      "location" : [ "Bought" , "crafted" ],
+      "location" : [ "Bought" , "Crafted" ],
       "quantity": "N/A",
       "forage": "N/A",
       "weight": "2",
@@ -182,7 +182,7 @@
    {
       "name": "Lyrian Leather",
       "rarity": "P",
-      "location" : [ "Bought" , "crafted" ],
+      "location" : [ "Bought" , "Crafted" ],
       "quantity": "N/A",
       "forage": "N/A",
       "weight": "2",
@@ -209,7 +209,7 @@
    {
       "name": "Drake Oil",
       "rarity": "P",
-      "location" : [ "Rivers" , "coasts" ],
+      "location" : [ "Rivers" , "Coasts" ],
       "quantity": "1d6 Units",
       "forage": "16",
       "weight": ".1",
@@ -218,7 +218,7 @@
    {
       "name": "Ester Grease",
       "rarity": "C",
-      "location" : [ "Forests" , "fields" ],
+      "location" : [ "Forests" , "Fields" ],
       "quantity": "1d10 Units",
       "forage": "14",
       "weight": ".1",
@@ -227,7 +227,7 @@
    {
       "name": "Etching Acid",
       "rarity": "C",
-      "location" : [ "Caves" , "mountains" ],
+      "location" : [ "Caves" , "Mountains" ],
       "quantity": "1d10 Units",
       "forage": "14",
       "weight": ".1",
@@ -236,7 +236,7 @@
    {
       "name": "Fifth Essence",
       "rarity": "R",
-      "location" : [ "Places of Power" , "mages" , "fiends" ],
+      "location" : [ "Places of Power" , "Mages" , "Fiends" ],
       "quantity": "Variable",
       "forage": "N/A",
       "weight": ".1",
@@ -254,7 +254,7 @@
    {
       "name": "Sharpening Grit",
       "rarity": "P",
-      "location" : [ "Mountains" , "caves" ],
+      "location" : [ "Mountains" , "Caves" ],
       "quantity": "1d6 Units",
       "forage": "16",
       "weight": ".1",
@@ -263,7 +263,7 @@
    {
       "name": "Tanning Herbs",
       "rarity": "C",
-      "location" : [ "Fields" , "forests" ],
+      "location" : [ "Fields" , "Forests" ],
       "quantity": "1d10 Units",
       "forage": "14",
       "weight": ".1",
@@ -272,7 +272,7 @@
    {
       "name": "Dark Iron",
       "rarity": "R",
-      "location" : [ "Mountains" , "underground" ],
+      "location" : [ "Mountains" , "Underground" ],
       "quantity": "1d6 Units",
       "forage": "18",
       "weight": "1.5",
@@ -281,7 +281,7 @@
    {
       "name": "Dark Steel",
       "rarity": "R",
-      "location" : [ "Bought" , "crafted" ],
+      "location" : [ "Bought" , "Crafted" ],
       "quantity": "N/A",
       "forage": "N/A",
       "weight": "1",
@@ -290,7 +290,7 @@
    {
       "name": "Dimeritium",
       "rarity": "R",
-      "location" : [ "Bought" , "crafted" ],
+      "location" : [ "Bought" , "Crafted" ],
       "quantity": "N/A",
       "forage": "N/A",
       "weight": "1",
@@ -299,7 +299,7 @@
    {
       "name": "Gemstone",
       "rarity": "R",
-      "location" : [ "Mountains" , "underground" ],
+      "location" : [ "Mountains" , "Underground" ],
       "quantity": "1d6/2 Units",
       "forage": "24",
       "weight": ".1",
@@ -308,7 +308,7 @@
    {
       "name": "Glowing Ore",
       "rarity": "R",
-      "location" : [ "Mountains" , "underground" ],
+      "location" : [ "Mountains" , "Underground" ],
       "quantity": "1d6/2 Units",
       "forage": "20",
       "weight": "1",
@@ -317,7 +317,7 @@
    {
       "name": "Gold",
       "rarity": "R",
-      "location" : [ "Mountains" , "underground" ],
+      "location" : [ "Mountains" , "Underground" ],
       "quantity": "1d6/2 Units",
       "forage": "18",
       "weight": "1",
@@ -326,7 +326,7 @@
    {
       "name": "Iron",
       "rarity": "P",
-      "location" : [ "Mountains" , "underground" ],
+      "location" : [ "Mountains" , "Underground" ],
       "quantity": "1d6 Units",
       "forage": "16",
       "weight": "1.5",
@@ -335,7 +335,7 @@
    {
       "name": "Mahakaman Dimeritium",
       "rarity": "R",
-      "location" : [ "Bought" , "crafted" ],
+      "location" : [ "Bought" , "Crafted" ],
       "quantity": "N/A",
       "forage": "N/A",
       "weight": "1",
@@ -344,7 +344,7 @@
    {
       "name": "Mahakaman Steel",
       "rarity": "P",
-      "location" : [ "Bought" , "crafted" ],
+      "location" : [ "Bought" , "Crafted" ],
       "quantity": "N/A",
       "forage": "N/A",
       "weight": "1",
@@ -362,7 +362,7 @@
    {
       "name": "River Clay",
       "rarity": "P",
-      "location" : [ "Rivers" , "shores" ],
+      "location" : [ "Rivers" , "Shore" ],
       "quantity": "1d6 Units",
       "forage": "14",
       "weight": "1.5",
@@ -371,7 +371,7 @@
    {
       "name": "Silver",
       "rarity": "R",
-      "location" : [ "Mountains" , "underground" ],
+      "location" : [ "Mountains" , "Underground" ],
       "quantity": "1d6/2 Units",
       "forage": "16",
       "weight": "1",
@@ -380,7 +380,7 @@
    {
       "name": "Steel",
       "rarity": "P",
-      "location" : [ "Bought" , "crafted" ],
+      "location" : [ "Bought" , "Crafted" ],
       "quantity": "N/A",
       "forage": "N/A",
       "weight": "1",
@@ -398,7 +398,7 @@
    {
       "name": "Tretogor Steel",
       "rarity": "P",
-      "location" : [ "Bought" , "crafted" ],
+      "location" : [ "Bought" , "Crafted" ],
       "quantity": "N/A",
       "forage": "N/A",
       "weight": "1",
@@ -407,7 +407,7 @@
    {
       "name": "Zerrikanian Powder",
       "rarity": "P",
-      "location" : [ "Mountains" , "underground" ],
+      "location" : [ "Mountains" , "Underground" ],
       "quantity": "1d6/2 Units",
       "forage": "18",
       "weight": ".1",

--- a/src/CraftingIngredients.json
+++ b/src/CraftingIngredients.json
@@ -1,0 +1,416 @@
+[
+   {
+      "name": "Ashes",
+      "rarity": "E",
+      "location" : [ "Fires" , "burned items" ],
+      "quantity": "1d10 Units",
+      "forage": "10",
+      "weight": ".1",
+      "cost": "1"
+   },
+   {
+      "name": "Coal",
+      "rarity": "C",
+      "location" : [ "Fires" , "mountains" , "underground" ],
+      "quantity": "1d10 Units",
+      "forage": "14",
+      "weight": ".1",
+      "cost": "1"
+   },
+   {
+      "name": "Cotton",
+      "rarity": "C",
+      "location" : [ "Fields" , "plantations" ],
+      "quantity": "1d10 Units",
+      "forage": "12",
+      "weight": ".1",
+      "cost": "1"
+   },
+   {
+      "name": "Double Woven Linen",
+      "rarity": "P",
+      "location" : [ "Bought" , "crafted" ],
+      "quantity": "N/A",
+      "forage": "N/A",
+      "weight": ".1",
+      "cost": "22"
+   },
+   {
+      "name": "Glass",
+      "rarity": "P",
+      "location" : [ "Bought" , "crafted" ],
+      "quantity": "N/A",
+      "forage": "N/A",
+      "weight": ".5",
+      "cost": "5"
+   },
+   {
+      "name": "Hardened Timber",
+      "rarity": "P",
+      "location" : [ "Bought" , "crafted" ],
+      "quantity": "N/A",
+      "forage": "N/A",
+      "weight": ".1",
+      "cost": "16"
+   },
+   {
+      "name": "Linen",
+      "rarity": "C",
+      "location" : [ "Bought" , "crafted" ],
+      "quantity": "N/A",
+      "forage": "N/A",
+      "weight": ".1",
+      "cost": "9"
+   },
+   {
+      "name": "Oil",
+      "rarity": "C",
+      "location" : [ "Bought" , "crafted" ],
+      "quantity": "N/A",
+      "forage": "N/A",
+      "weight": ".1",
+      "cost": "3"
+   },
+   {
+      "name": "Resin",
+      "rarity": "C",
+      "location" : [ "Forests" ],
+      "quantity": "1d6 Units",
+      "forage": "10",
+      "weight": ".1",
+      "cost": "2"
+   },
+   {
+      "name": "Silk",
+      "rarity": "P",
+      "location" : [ "Bought" ],
+      "quantity": "N/A",
+      "forage": "N/A",
+      "weight": ".1",
+      "cost": "50"
+   },
+   {
+      "name": "Thread",
+      "rarity": "C",
+      "location" : [ "Bought" , "crafted" ],
+      "quantity": "N/A",
+      "forage": "N/A",
+      "weight": ".1",
+      "cost": "3"
+   },
+   {
+      "name": "Timber",
+      "rarity": "E",
+      "location" : [ "Forests" ],
+      "quantity": "2d6 Units",
+      "forage": "8",
+      "weight": "1",
+      "cost": "3"
+   },
+   {
+      "name": "Wax",
+      "rarity": "C",
+      "location" : [ "Forests" , "fields" ],
+      "quantity": "1d6 Units",
+      "forage": "12",
+      "weight": ".1",
+      "cost": "2"
+   },
+   {
+      "name": "Beast Bones",
+      "rarity": "C",
+      "location" : [ "Found on monsters" , "beasts" ],
+      "quantity": "Variable",
+      "forage": "N/A",
+      "weight": "4",
+      "cost": "8"
+   },
+   {
+      "name": "Cow Hide",
+      "rarity": "C",
+      "location" : [ "Bought" ],
+      "quantity": "N/A",
+      "forage": "N/A",
+      "weight": "5",
+      "cost": "10"
+   },
+   {
+      "name": "Draconid Leather",
+      "rarity": "R",
+      "location" : [ "Bought" , "crafted" ],
+      "quantity": "N/A",
+      "forage": "N/A",
+      "weight": "5",
+      "cost": "58"
+   },
+   {
+      "name": "Draconid Scales",
+      "rarity": "R",
+      "location" : [ "Found on wyverns" ],
+      "quantity": "1d6 Units",
+      "forage": "N/A",
+      "weight": "5",
+      "cost": "30"
+   },
+   {
+      "name": "Feathers",
+      "rarity": "E",
+      "location" : [ "Found on birds" ],
+      "quantity": "1d6 Units",
+      "forage": "N/A",
+      "weight": ".1",
+      "cost": "4"
+   },
+   {
+      "name": "Hardened Leather",
+      "rarity": "P",
+      "location" : [ "Bought" , "crafted" ],
+      "quantity": "N/A",
+      "forage": "N/A",
+      "weight": "3",
+      "cost": "48"
+   },
+   {
+      "name": "Leather",
+      "rarity": "C",
+      "location" : [ "Bought" , "crafted" ],
+      "quantity": "N/A",
+      "forage": "N/A",
+      "weight": "2",
+      "cost": "28"
+   },
+   {
+      "name": "Lyrian Leather",
+      "rarity": "P",
+      "location" : [ "Bought" , "crafted" ],
+      "quantity": "N/A",
+      "forage": "N/A",
+      "weight": "2",
+      "cost": "60"
+   },
+   {
+      "name": "Wolf Hide",
+      "rarity": "C",
+      "location" : [ "Found on wolves" ],
+      "quantity": "3 Units",
+      "forage": "N/A",
+      "weight": "3",
+      "cost": "14"
+   },
+   {
+      "name": "Darkening Oil",
+      "rarity": "P",
+      "location" : [ "Forests" ],
+      "quantity": "1d6 Units",
+      "forage": "16",
+      "weight": ".1",
+      "cost": "24"
+   },
+   {
+      "name": "Drake Oil",
+      "rarity": "P",
+      "location" : [ "Rivers" , "coasts" ],
+      "quantity": "1d6 Units",
+      "forage": "16",
+      "weight": ".1",
+      "cost": "45"
+   },
+   {
+      "name": "Ester Grease",
+      "rarity": "C",
+      "location" : [ "Forests" , "fields" ],
+      "quantity": "1d10 Units",
+      "forage": "14",
+      "weight": ".1",
+      "cost": "8"
+   },
+   {
+      "name": "Etching Acid",
+      "rarity": "C",
+      "location" : [ "Caves" , "mountains" ],
+      "quantity": "1d10 Units",
+      "forage": "14",
+      "weight": ".1",
+      "cost": "2"
+   },
+   {
+      "name": "Fifth Essence",
+      "rarity": "R",
+      "location" : [ "Places of Power" , "mages" , "fiends" ],
+      "quantity": "Variable",
+      "forage": "N/A",
+      "weight": ".1",
+      "cost": "82"
+   },
+   {
+      "name": "Ogre Wax",
+      "rarity": "C",
+      "location" : [ "Caves" ],
+      "quantity": "1d10 Units",
+      "forage": "14",
+      "weight": ".1",
+      "cost": "10"
+   },
+   {
+      "name": "Sharpening Grit",
+      "rarity": "P",
+      "location" : [ "Mountains" , "caves" ],
+      "quantity": "1d6 Units",
+      "forage": "16",
+      "weight": ".1",
+      "cost": "32"
+   },
+   {
+      "name": "Tanning Herbs",
+      "rarity": "C",
+      "location" : [ "Fields" , "forests" ],
+      "quantity": "1d10 Units",
+      "forage": "14",
+      "weight": ".1",
+      "cost": "3"
+   },
+   {
+      "name": "Dark Iron",
+      "rarity": "R",
+      "location" : [ "Mountains" , "underground" ],
+      "quantity": "1d6 Units",
+      "forage": "18",
+      "weight": "1.5",
+      "cost": "52"
+   },
+   {
+      "name": "Dark Steel",
+      "rarity": "R",
+      "location" : [ "Bought" , "crafted" ],
+      "quantity": "N/A",
+      "forage": "N/A",
+      "weight": "1",
+      "cost": "82"
+   },
+   {
+      "name": "Dimeritium",
+      "rarity": "R",
+      "location" : [ "Bought" , "crafted" ],
+      "quantity": "N/A",
+      "forage": "N/A",
+      "weight": "1",
+      "cost": "240"
+   },
+   {
+      "name": "Gemstone",
+      "rarity": "R",
+      "location" : [ "Mountains" , "underground" ],
+      "quantity": "1d6/2 Units",
+      "forage": "24",
+      "weight": ".1",
+      "cost": "100"
+   },
+   {
+      "name": "Glowing Ore",
+      "rarity": "R",
+      "location" : [ "Mountains" , "underground" ],
+      "quantity": "1d6/2 Units",
+      "forage": "20",
+      "weight": "1",
+      "cost": "80"
+   },
+   {
+      "name": "Gold",
+      "rarity": "R",
+      "location" : [ "Mountains" , "underground" ],
+      "quantity": "1d6/2 Units",
+      "forage": "18",
+      "weight": "1",
+      "cost": "85"
+   },
+   {
+      "name": "Iron",
+      "rarity": "P",
+      "location" : [ "Mountains" , "underground" ],
+      "quantity": "1d6 Units",
+      "forage": "16",
+      "weight": "1.5",
+      "cost": "30"
+   },
+   {
+      "name": "Mahakaman Dimeritium",
+      "rarity": "R",
+      "location" : [ "Bought" , "crafted" ],
+      "quantity": "N/A",
+      "forage": "N/A",
+      "weight": "1",
+      "cost": "300"
+   },
+   {
+      "name": "Mahakaman Steel",
+      "rarity": "P",
+      "location" : [ "Bought" , "crafted" ],
+      "quantity": "N/A",
+      "forage": "N/A",
+      "weight": "1",
+      "cost": "114"
+   },
+   {
+      "name": "Meteorite",
+      "rarity": "R",
+      "location" : [ "Anywhere above ground" ],
+      "quantity": "1d6/2 Units",
+      "forage": "24",
+      "weight": "1",
+      "cost": "98"
+   },
+   {
+      "name": "River Clay",
+      "rarity": "P",
+      "location" : [ "Rivers" , "shores" ],
+      "quantity": "1d6 Units",
+      "forage": "14",
+      "weight": "1.5",
+      "cost": "5"
+   },
+   {
+      "name": "Silver",
+      "rarity": "R",
+      "location" : [ "Mountains" , "underground" ],
+      "quantity": "1d6/2 Units",
+      "forage": "16",
+      "weight": "1",
+      "cost": "72"
+   },
+   {
+      "name": "Steel",
+      "rarity": "P",
+      "location" : [ "Bought" , "crafted" ],
+      "quantity": "N/A",
+      "forage": "N/A",
+      "weight": "1",
+      "cost": "48"
+   },
+   {
+      "name": "Stone",
+      "rarity": "E",
+      "location" : [ "Everywhere" ],
+      "quantity": "2d6 Units",
+      "forage": "8",
+      "weight": "2",
+      "cost": "4"
+   },
+   {
+      "name": "Tretogor Steel",
+      "rarity": "P",
+      "location" : [ "Bought" , "crafted" ],
+      "quantity": "N/A",
+      "forage": "N/A",
+      "weight": "1",
+      "cost": "64"
+   },
+   {
+      "name": "Zerrikanian Powder",
+      "rarity": "P",
+      "location" : [ "Mountains" , "underground" ],
+      "quantity": "1d6/2 Units",
+      "forage": "18",
+      "weight": ".1",
+      "cost": "30"
+   }
+]

--- a/src/Ingredient.svelte
+++ b/src/Ingredient.svelte
@@ -1,49 +1,6 @@
 <script>
   export let ingredient;
-
- // FIXME: make the colors more readable
-let black = "black";
-let blue = "blue";
-let brown = "brown";
-let green = "green";
-let grey = "grey";
-let red = "red";
-let yellow = "yellow";
-
-let styles = {
-  "Fields":green,
-  "Forests":green,
-  "Mountains":grey,
-  "Cities":grey,
-  "Underground":black,
-  "Caves":black,
-  "Swamps":brown,
-  "Ghouls":red,
-  "Nekkers":red,
-  "Rock Trolls":red,
-  "Wraiths":red,
-  "Drowners":red,
-  "Grave Hags":red,
-  "Sirens":red,
-  "Noon Wraiths":red,
-  "Griffins":red,
-  "Griffin Nests":red,
-  "Golems":red,
-  "Werewolves":red,
-  "Arachasae":red,
-  "Endrega":red,
-  "Endrega Nests":red,
-  "Fiends":red,
-  "Fiend Territory":red,
-  "Katakans":red,
-  "Wyverns":red,
-  "Dogs":red,
-  "Wolves":red,
-  "Ocean floor":blue,
-  "Shore":blue,
-  "The Blue Mountains":blue,
-  "Breweries":yellow
-}
+  import { styles } from './Locations.svelte';
 
 </script>
 <style>

--- a/src/Ingredient.svelte
+++ b/src/Ingredient.svelte
@@ -1,0 +1,74 @@
+<script>
+  export let ingredient;
+
+ // FIXME: make the colors more readable
+let black = "black";
+let blue = "blue";
+let brown = "brown";
+let green = "green";
+let grey = "grey";
+let red = "red";
+let yellow = "yellow";
+
+let styles = {
+  "Fields":green,
+  "Forests":green,
+  "Mountains":grey,
+  "Cities":grey,
+  "Underground":black,
+  "Caves":black,
+  "Swamps":brown,
+  "Ghouls":red,
+  "Nekkers":red,
+  "Rock Trolls":red,
+  "Wraiths":red,
+  "Drowners":red,
+  "Grave Hags":red,
+  "Sirens":red,
+  "Noon Wraiths":red,
+  "Griffins":red,
+  "Griffin Nests":red,
+  "Golems":red,
+  "Werewolves":red,
+  "Arachasae":red,
+  "Endrega":red,
+  "Endrega Nests":red,
+  "Fiends":red,
+  "Fiend Territory":red,
+  "Katakans":red,
+  "Wyverns":red,
+  "Dogs":red,
+  "Wolves":red,
+  "Ocean floor":blue,
+  "Shore":blue,
+  "The Blue Mountains":blue,
+  "Breweries":yellow
+}
+
+</script>
+<style>
+  .purple-bg {
+    background-color: purple;
+  }
+  .room-right {
+    margin-right: 8px;
+  }
+</style>
+
+<tr>
+  <td>{ingredient.name}</td>
+    <td>
+      {#each ingredient.location as l}
+        {#if styles[l] != undefined }
+          <span class="badge room-right" style="background-color: {styles[l]}; color: #fff;"> {l}</span>
+        {:else}
+          FIXME: {l}
+        {/if}
+      {/each}
+    </td>
+  <td>{ingredient.rarity}</td>
+  <td>{ingredient.quantity}</td>
+  <td>{ingredient.forage}</td>
+  <td>{ingredient.weight}</td>
+  <td>{ingredient.cost}</td>
+</tr>

--- a/src/Locations.svelte
+++ b/src/Locations.svelte
@@ -1,0 +1,62 @@
+<script context="module">
+// FIXME: make the colors more readable
+const black = "black";
+const blue = "blue";
+const brown = "brown";
+const green = "green";
+const grey = "grey";
+const red = "red";
+// Yellow is very unreadable
+const yellow = "yellow";
+
+export const styles = {
+  "Anywhere above ground":brown,
+  "Arachasae":red,
+  "Breweries":yellow,
+  "Bought":yellow,
+  "Burned items":red,
+  "Caves":black,
+  "Coasts":blue,
+  "Cities":grey,
+  "Crafted":yellow,
+  "Dogs":red,
+  "Drowners":red,
+  "Endrega Nests":red,
+  "Endrega":red,
+  "Everywhere":brown,
+  "Fields":green,
+  "Fiend Territory":red,
+  "Fiends":red,
+  "Fires":red,
+  "Forests":green,
+  "Found on birds":red,
+  "Found on monsters & beasts":red,
+  "Found on monsters":red,
+  "Found on wolves":red,
+  "Found on wyverns":red,
+  "Ghouls":red,
+  "Golems":red,
+  "Grave Hags":red,
+  "Griffin Nests":red,
+  "Griffins":red,
+  "Katakans":red,
+  "Mages":black,
+  "Mountains":grey,
+  "Nekkers":red,
+  "Noon Wraiths":red,
+  "Ocean floor":blue,
+  "Plantations":green,
+  "Places of Power":black,
+  "Rivers":blue,
+  "Rock Trolls":red,
+  "Shore":blue,
+  "Sirens":red,
+  "Swamps":brown,
+  "The Blue Mountains":blue,
+  "Underground":black,
+  "Werewolves":red,
+  "Wolves":red,
+  "Wraiths":red,
+  "Wyverns":red,
+}
+</script>

--- a/src/Locations.svelte
+++ b/src/Locations.svelte
@@ -1,0 +1,62 @@
+<script context="module">
+// FIXME: make the colors more readable
+const black = "black";
+const blue = "blue";
+const brown = "brown";
+const green = "green";
+const grey = "grey";
+const red = "red";
+// Yellow is very unreadable
+const yellow = "yellow";
+
+export const styles = {
+  "Anywhere above ground":brown,
+  "Arachasae":red,
+  "Breweries":yellow,
+  "Bought":yellow,
+  "Burned items":red,
+  "Caves":black,
+  "Coasts":blue,
+  "Cities":grey,
+  "Crafted":yellow,
+  "Dogs":red,
+  "Drowners":red,
+  "Endrega Nests":red,
+  "Endrega":red,
+  "Everywhere":brown,
+  "Fields":green,
+  "Fiend Territory":red,
+  "Fiends":red,
+  "Fires":red,
+  "Forests":green,
+  "Found on birds":red,
+  "Found on monsters & beasts":red,
+  "Found on monsters":red,
+  "Found on wolves":red,
+  "Found on wyverns":red,
+  "Ghouls":red,
+  "Golems":red,
+  "Grave Hags":red,
+  "Griffin Nests":red,
+  "Griffins":red,
+  "Katakans":red,
+  "Mages":black,
+  "Mountains":grey,
+  "Nekkers":red,
+  "Noon Wraiths":red,
+  "Ocean floor":blue,
+  "Plantations":green,
+  "Places of power":black,
+  "Rivers":blue,
+  "Rock Trolls":red,
+  "Shore":blue,
+  "Sirens":red,
+  "Swamps":brown,
+  "The Blue Mountains":blue,
+  "Underground":black,
+  "Werewolves":red,
+  "Wolves":red,
+  "Wraiths":red,
+  "Wyverns":red,
+}
+</script>

--- a/src/Substance.svelte
+++ b/src/Substance.svelte
@@ -1,50 +1,7 @@
 <script>
   export let substance;
   import Component from './Component.svelte';
-
- // FIXME: make the colors more readable
-let black = "black";
-let blue = "blue";
-let brown = "brown";
-let green = "green";
-let grey = "grey";
-let red = "red";
-let yellow = "yellow";
-
-let styles = {
-  "Fields":green,
-  "Forests":green,
-  "Mountains":grey,
-  "Cities":grey,
-  "Underground":black,
-  "Caves":black,
-  "Swamps":brown,
-  "Ghouls":red,
-  "Nekkers":red,
-  "Rock Trolls":red,
-  "Wraiths":red,
-  "Drowners":red,
-  "Grave Hags":red,
-  "Sirens":red,
-  "Noon Wraiths":red,
-  "Griffins":red,
-  "Griffin Nests":red,
-  "Golems":red,
-  "Werewolves":red,
-  "Arachasae":red,
-  "Endrega":red,
-  "Endrega Nests":red,
-  "Fiends":red,
-  "Fiend Territory":red,
-  "Katakans":red,
-  "Wyverns":red,
-  "Dogs":red,
-  "Wolves":red,
-  "Ocean floor":blue,
-  "Shore":blue,
-  "The Blue Mountains":blue,
-  "Breweries":yellow
-}
+  import { styles } from './Locations.svelte';
 
 </script>
 <style>


### PR DESCRIPTION
The review primarily adds all of the crafting ingredients to the completor. It also refactors portions of the program to share between the Substances and Ingredients, in order to better share them among the files. Finally, it adds more location colors, to fix all the ones for Crafting Ingredients.